### PR TITLE
add sp support for encrypted attributes

### DIFF
--- a/examples/sp.py
+++ b/examples/sp.py
@@ -35,6 +35,11 @@ app.config['SAML2_IDENTITY_PROVIDERS'] = [
             'sso_url': 'http://localhost:8000/saml/login/',
             'slo_url': 'http://localhost:8000/saml/logout/',
             'certificate': IDP_CERTIFICATE,
+            # for decrypting attributes with xmlsec1
+            # 'encrypted_attributes': {
+            #     'xmlsec1_path': 'xmlsec1',
+            #     'sp_key_path': '../testd/keys/sample/sp-private-key.pem',
+            # },
         },
     },
 ]

--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -76,6 +76,7 @@ class IdPHandler:
         sso_url: Optional[str] = None,
         slo_url: Optional[str] = None,
         certificate: Optional[X509] = None,
+        encrypted_attributes: Mapping[str, str] = None,
         **kwargs,
     ):
         """
@@ -99,11 +100,18 @@ class IdPHandler:
 
         The ``sso_url``, ``slo_url``, and ``certificate`` can all be found in
         the IdP's metadata.
+
+        ``encrypted_attributes`` is a map with extra configuration for decrypting
+        the saml EncryptedAttributes tag using xmlsec1. this requires installing
+        the xmlsec1 program to work. the map consists of ``xmlsec1_path`` and
+        ``sp_key_path``, which are paths to an xmlsec1 binary and your sp's key
+        for decrypting the attributes
         """
         super().__init__(**kwargs)
 
         self.sp = sp
         self.entity_id = entity_id
+        self.encrypted_attributes = encrypted_attributes
 
         if display_name is not None:
             self.display_name = display_name
@@ -219,7 +227,8 @@ class IdPHandler:
         """
         return ResponseParser(
             self.decode_saml_string(saml_response),
-            certificate=self.certificate)
+            certificate=self.certificate,
+            encrypted_attributes=self.encrypted_attributes)
 
     def get_auth_data(self, response: ResponseParser) -> AuthData:
         """

--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -107,7 +107,6 @@ class IdPHandler:
         ``sp_key_path``, which are paths to an xmlsec1 binary and your sp's key
         for decrypting the attributes
         """
-        super().__init__(**kwargs)
 
         self.sp = sp
         self.entity_id = entity_id


### PR DESCRIPTION
I needed to use encrypted attributes in my application and wanted to use this library since its fairly simple, so i added support for it. it requires the xmlsec1 program to be installed because it uses it via sub process. there is a python library for xmlsec but I experienced a lot of difficulties using it and pysaml2 does something similar with xmlsec1 so I thought I'd try it.

I ran into an error where there was a `super().__init__()` call to object but it said it didn't take any parameters so i just removed the super call.

I'm not sure what else is required to merge this, I could potentially add a test by generating a request and then using xmlsec1 by hand to encrypt it.